### PR TITLE
Fix single node's children not sorted issue

### DIFF
--- a/TeeGenericTree.pas
+++ b/TeeGenericTree.pas
@@ -390,14 +390,12 @@ procedure TNode<T>.Sort(const ACompare: TCompareProc; const Recursive: Boolean);
 var t : TInteger;
 begin
   if Count>1 then
-  begin
     PrivateSort(ACompare,0,Count-1);
 
-    // Optionally, re-order all children-children... nodes
-    if Recursive then
-       for t:=0 to Count-1 do
-           Items[t].Sort(ACompare,Recursive);
-  end;
+  //Optionally, re-order all children-children... nodes
+  if Recursive then
+    for t:=0 to Count-1 do
+      Items[t].Sort(ACompare,Recursive);
 end;
 
 end.


### PR DESCRIPTION
The TNode<T>.Sort method didn't traverse children nodes (ChildCount > 1) which their parent was the single node in same node level. Provided with simple testcase to replay the issue as below:

```pascal
procedure TTestCase_TeeGenericTree_DataSet.Test1;
begin
  var O := TNode<integer>.Create; 
  try
    var N := O.Add(1);
    N.Add(22);
    N.Add(11);
    O.Sort(
      function (const ANode1, ANode2: TNode<integer>): Integer
      begin
        Result := ANode1.Data - ANode2.Data;  //sort ascending
      end
    );

    CheckEquals(1,         O.Count);
    CheckEquals(1,         O[0].Data);
    CheckEquals(2,         O[0].Count);
    CheckEquals(11,        O[0][0].Data);
    CheckEquals(22,        O[0][1].Data);
  finally
    O.Free;
  end;
end;
```